### PR TITLE
Break up the Semantic UI imports

### DIFF
--- a/src/client/assets/App.scss
+++ b/src/client/assets/App.scss
@@ -1,6 +1,7 @@
 $icons-font-path: "~semantic-ui-sass/icons";
 $flags-image-path: "~semantic-ui-sass/images";
-@import "~semantic-ui-sass/semantic-ui";
+
+@import "styles/semantic-import";
 
 body {
   margin: 0;

--- a/src/client/assets/styles/semantic-import.scss
+++ b/src/client/assets/styles/semantic-import.scss
@@ -1,0 +1,61 @@
+// Globals
+
+@import '~semantic-ui-sass/scss/globals/variables';
+@import '~semantic-ui-sass/scss/globals/reset';
+@import '~semantic-ui-sass/scss/globals/site';
+
+// Elements
+
+@import '~semantic-ui-sass/scss/elements/button';
+@import '~semantic-ui-sass/scss/elements/container';
+@import '~semantic-ui-sass/scss/elements/divider';
+@import '~semantic-ui-sass/scss/elements/flag';
+@import '~semantic-ui-sass/scss/elements/header';
+@import '~semantic-ui-sass/scss/elements/icon';
+@import '~semantic-ui-sass/scss/elements/image';
+@import '~semantic-ui-sass/scss/elements/input';
+@import '~semantic-ui-sass/scss/elements/label';
+@import '~semantic-ui-sass/scss/elements/list';
+@import '~semantic-ui-sass/scss/elements/loader';
+@import '~semantic-ui-sass/scss/elements/rail';
+@import '~semantic-ui-sass/scss/elements/reveal';
+@import '~semantic-ui-sass/scss/elements/segment';
+@import '~semantic-ui-sass/scss/elements/step';
+
+// Modules
+
+@import '~semantic-ui-sass/scss/modules/accordion';
+@import '~semantic-ui-sass/scss/modules/checkbox';
+@import '~semantic-ui-sass/scss/modules/dimmer';
+@import '~semantic-ui-sass/scss/modules/dropdown';
+@import '~semantic-ui-sass/scss/modules/embed';
+@import '~semantic-ui-sass/scss/modules/modal';
+@import '~semantic-ui-sass/scss/modules/nag';
+@import '~semantic-ui-sass/scss/modules/popup';
+@import '~semantic-ui-sass/scss/modules/progress';
+@import '~semantic-ui-sass/scss/modules/rating';
+@import '~semantic-ui-sass/scss/modules/search';
+@import '~semantic-ui-sass/scss/modules/shape';
+@import '~semantic-ui-sass/scss/modules/sidebar';
+@import '~semantic-ui-sass/scss/modules/sticky';
+@import '~semantic-ui-sass/scss/modules/tab';
+@import '~semantic-ui-sass/scss/modules/transition';
+@import '~semantic-ui-sass/scss/modules/video';
+
+// Collections
+
+@import '~semantic-ui-sass/scss/collections/breadcrumb';
+@import '~semantic-ui-sass/scss/collections/form';
+@import '~semantic-ui-sass/scss/collections/grid';
+@import '~semantic-ui-sass/scss/collections/menu';
+@import '~semantic-ui-sass/scss/collections/message';
+@import '~semantic-ui-sass/scss/collections/table';
+
+// Views
+
+@import '~semantic-ui-sass/scss/views/ad';
+@import '~semantic-ui-sass/scss/views/card';
+@import '~semantic-ui-sass/scss/views/comment';
+@import '~semantic-ui-sass/scss/views/feed';
+@import '~semantic-ui-sass/scss/views/item';
+@import '~semantic-ui-sass/scss/views/statistic';

--- a/src/shared/components/pages/Home/Home.tsx
+++ b/src/shared/components/pages/Home/Home.tsx
@@ -14,7 +14,7 @@ class Home extends React.Component<RouteComponentProps> {
                         <Grid.Column>
                             <Segment inverted={true} vertical={true} textAlign="center">
                                 <Container>
-                                    <Image className="app-logo" src={"/public/static/media/logo.svg"} />
+                                    <Image className="app-logo" src={"/static/media/logo.svg"} />
                                     <Header as="h1" inverted={true}>Welcome to TypeScript + React</Header>
                                     <p>Includes Semantic UI React, Redux and much more!</p>
                                 </Container>


### PR DESCRIPTION
Make it easier to pick and choose the semantic component styles we want instead of a single import.